### PR TITLE
Rename pcInput to pcInputText for DatePicker and InputNumber components

### DIFF
--- a/presets/aura/datepicker/index.js
+++ b/presets/aura/datepicker/index.js
@@ -10,7 +10,7 @@ export default {
             'relative'
         ]
     }),
-    pcInput: ({ props, parent }) => ({
+    pcInputText: ({ props, parent }) => ({
         root: {
             class: [
                 // Display

--- a/presets/aura/inputnumber/index.js
+++ b/presets/aura/inputnumber/index.js
@@ -17,7 +17,7 @@ export default {
             { '!w-16': props.showButtons && props.buttonLayout == 'vertical' }
         ]
     }),
-    pcInput: {
+    pcInputText: {
         root: ({ parent, context }) => ({
             class: [
                 // Font

--- a/presets/lara/datepicker/index.js
+++ b/presets/lara/datepicker/index.js
@@ -13,7 +13,7 @@ export default {
             { 'opacity-60 select-none pointer-events-none cursor-default': props.disabled }
         ]
     }),
-    pcInput: ({ props, parent }) => ({
+    pcInputText: ({ props, parent }) => ({
         root: {
             class: [
                 // Display

--- a/presets/lara/inputnumber/index.js
+++ b/presets/lara/inputnumber/index.js
@@ -17,7 +17,7 @@ export default {
             { '!w-16': props.showButtons && props.buttonLayout == 'vertical' }
         ]
     }),
-    pcInput: {
+    pcInputText: {
         root: ({ parent, context }) => ({
             class: [
                 // Display


### PR DESCRIPTION
Input text's passthrough option is `pcInput` while official doc states it is `pcInputText` instead.

See: https://primevue.org/datepicker/#pt.doc.datepicker
See: https://primevue.org/inputnumber/#pt.doc.inputnumber